### PR TITLE
feat: Role-based authorization middleware (R8)

### DIFF
--- a/app/Http/Middleware/EnsureUserIsAdmin.php
+++ b/app/Http/Middleware/EnsureUserIsAdmin.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserIsAdmin
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (!$request->user() || $request->user()->role !== 'admin') {
+            return response()->json([
+                'success' => false,
+                'message' => 'Forbidden. Admin access required.',
+            ], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,7 +13,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'role.admin' => \App\Http\Middleware\EnsureUserIsAdmin::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         $exceptions->renderable(function (AuthenticationException $e, $request) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,23 +11,21 @@ Route::get('/user', function (Request $request) {
 
 // API v1 - Public routes
 Route::prefix('v1')->group(function () {
-    // Authentication (public)
     Route::post('/auth/login', [AuthController::class, 'login']);
-    
-    // Catalog (public - read only)
     Route::get('/brands', [CatalogController::class, 'brands']);
     Route::get('/products', [CatalogController::class, 'products']);
     Route::get('/products/{id}', [CatalogController::class, 'show']);
 });
 
-// API v1 - Protected routes (require authentication)
+// API v1 - Protected routes
 Route::prefix('v1')->middleware('auth:sanctum')->group(function () {
-    // Authentication (protected)
     Route::post('/auth/logout', [AuthController::class, 'logout']);
     Route::get('/auth/me', [AuthController::class, 'me']);
     
-    // Catalog Management (CRUD - Admin only)
-    Route::post('/products', [CatalogController::class, 'store']);
-    Route::put('/products/{id}', [CatalogController::class, 'update']);
-    Route::delete('/products/{id}', [CatalogController::class, 'destroy']);
+    // Admin only - CRUD operations
+    Route::middleware('role.admin')->group(function () {
+        Route::post('/products', [CatalogController::class, 'store']);
+        Route::put('/products/{id}', [CatalogController::class, 'update']);
+        Route::delete('/products/{id}', [CatalogController::class, 'destroy']);
+    });
 });


### PR DESCRIPTION
## ✅ Implementación R8: Autorización por Roles

### Cambios:
- ✅ Middleware `EnsureUserIsAdmin` creado
- ✅ Alias `role.admin` registrado en bootstrap/app.php
- ✅ Rutas CRUD protegidas (solo admin)

### Tests:
- ✅ Admin puede crear productos → 201 Created
- ✅ Cliente recibe → 403 Forbidden
- ✅ Sin auth recibe → 401 Unauthorized

Closes #8